### PR TITLE
Fix headers already sent error in AuthController

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -57,12 +57,12 @@ class AuthController extends Controller
                     System::getContainer()->get('contao.insert_tag.parser');
                 $strBuffer = FrontendTemplate::replaceDynamicScriptTags($parser->replace((string) $objTemplate->parse()));
                 $response->setContent($strBuffer);
-                return $response->send();
-                exit;
+                $event->setResponse($response);
+                return;
             } else {
                 if (Input::get('protect_page_auth') == 1) {
-                    $response = new RedirectResponse($request->getPathInfo(), 302);
-                    return $response->send();
+                    $event->setResponse(new RedirectResponse($request->getPathInfo(), 302));
+                    return;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Replace direct `$response->send()` calls with `$event->setResponse()` in the `kernel.response` event listener
- Calling `send()` directly outputs headers immediately, causing a "Cannot modify header information" warning when Symfony sends the response a second time

## Changes
- `AuthController::__invoke()`: Use `$event->setResponse($response)` instead of `$response->send()` for both the auth template and the redirect after successful authentication